### PR TITLE
chore: Minor change to use https in the github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Helmut Januschka <helmut@januschka.com>"]
 edition = "2018"
 license = "MIT"
 description = "KRN Auth"
-homepage = "http://github.com/KroneMultimedia/krn-auth-rust"
-repository = "http://github.com/KroneMultimedia/krn-auth-rust"
+homepage = "https://github.com/KroneMultimedia/krn-auth-rust"
+repository = "https://github.com/KroneMultimedia/krn-auth-rust"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
GitHub redirects to the address with https anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/97